### PR TITLE
Remove backlight setting failure check.

### DIFF
--- a/backlight.el
+++ b/backlight.el
@@ -130,10 +130,7 @@
 (defun backlight--set-brightness (value)
   "Set and verify the backlight brightness to raw VALUE."
   (backlight--set "brightness" value)
-  (let ((actual (backlight--get "actual_brightness")))
-    (when (not (equal actual value))
-      (error "Failed to set backlight brightness"))
-    (setq backlight--current-brightness actual)))
+  (setq backlight--current-brightness (backlight--get "actual_brightness")))
 
 (defun backlight--from-percent (percent)
   "Convert a PERCENT to a brightness value the device accepts."


### PR DESCRIPTION
I think this check causes more problems than it’s worth.

 - Because the sysfs interface depends on the hardware brightness values, the value you set isn’t always what gets read back.  This causes issues, because backlight.el will set it to 21818, but when it reads it back, it gets 21817, which produces an error.  The backliche *was* changed, just not to the exact value requested.  The error message becomes confusing in this case.
 - I don’t think it’s a useful error because there’s nothing the user can do to fix it.  The hardware works or it doesn’t; the user can directly observe whether the brightness changed or didn’t.