### PR TITLE
Add backlight preference variable for systems with multiple devices

### DIFF
--- a/backlight.el
+++ b/backlight.el
@@ -65,6 +65,11 @@
   :type 'string
   :group 'backlight)
 
+(defcustom backlight-pref-device nil
+  "Preferred brightness device if multiple are available"
+  :type 'string
+  :group 'backlight)
+
 (defvar backlight--device nil
   "Filename of the backlight device.")
 
@@ -102,12 +107,19 @@
   "Find the backlight device file and read initial values."
   (let ((devices (cddr (and (file-exists-p backlight-sys-dir)
                             (directory-files backlight-sys-dir)))))
-    (when (> (length devices) 1)
-      ;; Don't know if this is actually possible
-      (message "Warning: Multiple backlight devices. Using the first."))
     (if (null devices)
         (message "Error: Unable to find backlight device")
-      (setq backlight--device (car devices))
+      (when (and (null backlight-pref-device)
+		 (> (length devices) 1))
+	(message (concat "Warning: Multiple backlight devices. Using the first, "
+			 (car devices))))
+      (when (and backlight-pref-device
+		 (not (member backlight-pref-device devices)))
+	(message (concat "Warning: Preferred backlight device not found, using "
+			 (car devices))))
+      (if (member backlight-pref-device devices)
+	  (setq backlight--device backlight-pref-device)
+	(setq backlight--device (car devices)))
       (setq backlight--max-brightness (backlight--get "max_brightness"))
       (backlight--read-current-brightness)
       (setq backlight--initialized t)))


### PR DESCRIPTION
On systems with multiple backlight devices (in my case, acpi0_video and intel_backlight), it is necessary to expose a variable for the user to input a device preference.  This PR implements:

-  A customizable variable with default nil storing device preference
    - Previous behavior is only changed if this variable's (non-nil) value is found in the devices list
- A new warning message for when the preference var is set but does not match a device
- Inclusion of the defaulted-to device name in warnings for more convenient user debugging